### PR TITLE
Update ntr.md

### DIFF
--- a/src/en/community/roleplay/jobs/ntr.md
+++ b/src/en/community/roleplay/jobs/ntr.md
@@ -1,7 +1,7 @@
 # Nanotrasen Representative
 ### Superiors: Central Command
 ### Difficulty: Hard
-### Access: All Access
+### Access: Command,Security,External,Cryogenics,Maintenance,Engineering,Medical,Research
 ### Duties: Oversee departments, give out orders sent by Central Command, and send regular reports on the station to Central Command.
 ![image](https://github.com/user-attachments/assets/94205237-a1d0-4832-8211-2d8bf262f795)
 

--- a/src/en/community/roleplay/jobs/ntr.md
+++ b/src/en/community/roleplay/jobs/ntr.md
@@ -1,7 +1,7 @@
 # Nanotrasen Representative
 ### Superiors: Central Command
 ### Difficulty: Hard
-### Access: Command,Security,External,Cryogenics,Maintenance,Engineering,Medical,Research
+### Access: "Command, Security, External, Cryogenics, Maintenance, Engineering, Medical, and Research."
 ### Duties: Oversee departments, give out orders sent by Central Command, and send regular reports on the station to Central Command.
 ![image](https://github.com/user-attachments/assets/94205237-a1d0-4832-8211-2d8bf262f795)
 


### PR DESCRIPTION
With https://github.com/Goob-Station/Goob-Station/pull/443 most likely getting merged I might as well make a pull request so the wiki can stay updated.
-Removed mention of All Access from Nanotrasen Representative and specified what access NTR has

-Before: Access: All Access
-After: Access: Command,Security,External,Cryogenics,Maintenance,Engineering,Medical,Research

Note: I left out Central Command access as I would assume people would have their own take on what Central Command access is and thought best to leave it out since no where on the station uses Central Command access unless we start adding an office for NTRs for stations